### PR TITLE
Add Harangle login page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
-# harangle-web
+# Harangle Web
+
+This repository contains the login page prototype for Harangle. Open `index.html` in a browser to view it.

--- a/assets/harangle-icon.svg
+++ b/assets/harangle-icon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <circle cx="50" cy="50" r="50" fill="#4B5EFF"/>
+  <text x="50" y="58" font-family="Poppins, sans-serif" font-size="60" fill="#FFFFFF" text-anchor="middle">H</text>
+</svg>

--- a/index.html
+++ b/index.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Harangle - Sign in</title>
+  <link rel="icon" type="image/svg+xml" href="assets/harangle-icon.svg" />
+  <link rel="stylesheet" href="styles.css" />
+  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&display=swap" rel="stylesheet" />
+  <script src="https://accounts.google.com/gsi/client" async defer></script>
+</head>
+<body>
+  <main class="login-container">
+    <img src="assets/harangle-icon.svg" class="logo" alt="Harangle logo" />
+    <h1 class="app-title">Harangle</h1>
+    <div id="g_id_onload"
+        data-client_id="YOUR_GOOGLE_CLIENT_ID"
+        data-context="signin"
+        data-ux_mode="popup"
+        data-callback="handleCredentialResponse">
+    </div>
+    <div class="g_id_signin" data-type="standard" data-size="large"></div>
+  </main>
+  <script>
+    function handleCredentialResponse(response) {
+      // Placeholder for handling ID token response.
+      console.log('Google ID token:', response.credential);
+    }
+  </script>
+</body>
+</html>

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,38 @@
+:root {
+  --primary-color: #4B5EFF;
+  --accent-color: #FF6F61;
+  --background-color: #F3F6FF;
+}
+
+body {
+  font-family: 'Poppins', sans-serif;
+  background: var(--background-color);
+  margin: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 100vh;
+}
+
+.login-container {
+  text-align: center;
+  padding: 2rem;
+  background: #fff;
+  border-radius: 8px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+}
+
+.logo {
+  width: 80px;
+  height: 80px;
+}
+
+.app-title {
+  color: var(--primary-color);
+  margin: 1rem 0;
+  font-size: 2rem;
+}
+
+.g_id_signin {
+  margin-top: 1rem;
+}


### PR DESCRIPTION
## Summary
- Build Harangle login page with Google sign-in button and brand styling
- Add stylesheet and SVG logo for Harangle branding
- Update README with instructions for viewing the prototype

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ae5affab8c832bab0fc1c62830b524