### PR TITLE
Add Harangle login and settings pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,6 @@
-# harangle-web
+# Harangle Web
+
+This repository contains the login and settings page prototypes for Harangle. Both pages rely on mocked data so they can be opened directly in a browser without running a server.
+
+- Open `index.html` in a browser to view the login page. If the Google sign-in script is unavailable, a mock button allows you to proceed to the settings page.
+- Open `settings.html` to view the settings page where you can edit your username, choose calendars, and review events.

--- a/assets/harangle-icon.svg
+++ b/assets/harangle-icon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <circle cx="50" cy="50" r="50" fill="#4B5EFF"/>
+  <text x="50" y="58" font-family="Poppins, sans-serif" font-size="60" fill="#FFFFFF" text-anchor="middle">H</text>
+</svg>

--- a/index.html
+++ b/index.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Harangle - Sign in</title>
+  <link rel="icon" type="image/svg+xml" href="assets/harangle-icon.svg" />
+  <link rel="stylesheet" href="styles.css" />
+  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&display=swap" rel="stylesheet" />
+  <script src="https://accounts.google.com/gsi/client" async defer></script>
+</head>
+<body>
+  <main class="login-container">
+    <img src="assets/harangle-icon.svg" class="logo" alt="Harangle logo" />
+    <h1 class="app-title">Harangle</h1>
+  <div id="g_id_onload"
+        data-client_id="YOUR_GOOGLE_CLIENT_ID"
+        data-context="signin"
+        data-ux_mode="popup"
+        data-callback="handleCredentialResponse">
+  </div>
+  <div class="g_id_signin" data-type="standard" data-size="large"></div>
+  <button id="mock-signin-button" class="mock-signin hidden">Mock Sign In</button>
+</main>
+<script>
+  function handleCredentialResponse(response) {
+    // Placeholder for handling ID token response.
+    console.log('Google ID token:', response.credential);
+  }
+
+  window.addEventListener('load', () => {
+    if (typeof google === 'undefined') {
+      const mockBtn = document.getElementById('mock-signin-button');
+      mockBtn.classList.remove('hidden');
+      mockBtn.addEventListener('click', () => {
+        console.log('Mock sign-in');
+        window.location.href = 'settings.html';
+      });
+    }
+  });
+</script>
+</body>
+</html>

--- a/settings.css
+++ b/settings.css
@@ -1,0 +1,84 @@
+body {
+  font-family: 'Poppins', sans-serif;
+  background: var(--background-color);
+  margin: 0;
+  padding: 2rem;
+  display: block;
+}
+
+.settings-container {
+  max-width: 600px;
+  margin: 0 auto;
+  background: #fff;
+  padding: 1rem 2rem;
+  border-radius: 8px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+}
+
+.page-title {
+  color: var(--primary-color);
+  margin-top: 0;
+  text-align: center;
+}
+
+.section {
+  margin-bottom: 1.5rem;
+}
+
+.calendars-list .calendar-item {
+  display: flex;
+  align-items: center;
+  margin-bottom: 0.5rem;
+}
+
+.calendar-item input[type="radio"] {
+  margin-right: 0.5rem;
+}
+
+.events-list {
+  max-height: 200px;
+  overflow-y: auto;
+  border: 1px solid #ddd;
+  padding: 0.5rem;
+}
+
+.events-list div {
+  margin-bottom: 0.5rem;
+}
+
+button {
+  background: var(--primary-color);
+  color: #fff;
+  border: none;
+  padding: 0.75rem 1.5rem;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 1rem;
+}
+
+button:disabled {
+  background: #ccc;
+  cursor: not-allowed;
+}
+
+.skeleton {
+  background: #e0e0e0;
+  border-radius: 4px;
+  animation: pulse 1.5s infinite;
+}
+
+.skeleton.line {
+  height: 1rem;
+  margin-bottom: 0.5rem;
+}
+
+.skeleton.input {
+  height: 2rem;
+  width: 100%;
+}
+
+@keyframes pulse {
+  0% { opacity: 1; }
+  50% { opacity: 0.4; }
+  100% { opacity: 1; }
+}

--- a/settings.html
+++ b/settings.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Harangle - Settings</title>
+  <link rel="icon" type="image/svg+xml" href="assets/harangle-icon.svg" />
+  <link rel="stylesheet" href="styles.css" />
+  <link rel="stylesheet" href="settings.css" />
+  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&display=swap" rel="stylesheet" />
+  <script defer src="settings.js"></script>
+</head>
+<body>
+  <main class="settings-container">
+    <h1 class="page-title">Settings</h1>
+
+    <section class="section username-section">
+      <label for="username-input">Username</label>
+      <div id="username-skeleton" class="skeleton input"></div>
+      <input id="username-input" type="text" class="hidden" />
+    </section>
+
+    <section class="section calendars-section">
+      <h2>Calendars</h2>
+      <div id="calendars-list" class="calendars-list">
+        <div class="skeleton line"></div>
+        <div class="skeleton line"></div>
+      </div>
+    </section>
+
+    <section class="section events-section">
+      <h2>Events</h2>
+      <div id="events-list" class="events-list">
+        <div class="skeleton line"></div>
+        <div class="skeleton line"></div>
+        <div class="skeleton line"></div>
+      </div>
+    </section>
+
+    <button id="save-button" disabled>Save</button>
+  </main>
+</body>
+</html>

--- a/settings.js
+++ b/settings.js
@@ -1,0 +1,122 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const usernameInput = document.getElementById('username-input');
+  const usernameSkeleton = document.getElementById('username-skeleton');
+  const calendarsList = document.getElementById('calendars-list');
+  const eventsList = document.getElementById('events-list');
+  const saveButton = document.getElementById('save-button');
+
+  let selectedCalendars = new Set();
+
+  function fetchUser() {
+    return new Promise(resolve => {
+      setTimeout(() => {
+        resolve({ username: 'HarangleUser', calendars: ['cal-1', 'cal-2'] });
+      }, 800);
+    });
+  }
+
+  function fetchCalendars() {
+    return new Promise(resolve => {
+      setTimeout(() => {
+        resolve([
+          { id: 'cal-1', name: 'Work' },
+          { id: 'cal-2', name: 'Personal' },
+          { id: 'cal-3', name: 'Holidays' }
+        ]);
+      }, 1000);
+    });
+  }
+
+  const eventData = {
+    'cal-1': [
+      { id: 'e1', name: 'Team Meeting' },
+      { id: 'e2', name: 'Project Review' }
+    ],
+    'cal-2': [
+      { id: 'e3', name: 'Dentist Appointment' },
+      { id: 'e4', name: 'Gym Session' }
+    ],
+    'cal-3': [
+      { id: 'e5', name: 'Independence Day' }
+    ]
+  };
+
+  function fetchEvents(ids) {
+    return new Promise(resolve => {
+      setTimeout(() => {
+        let events = [];
+        ids.forEach(id => {
+          events = events.concat(eventData[id] || []);
+        });
+        resolve(events);
+      }, 700);
+    });
+  }
+
+  function renderCalendars(calendars, userCalendarIds) {
+    calendarsList.innerHTML = '';
+    calendars.forEach(cal => {
+      const label = document.createElement('label');
+      label.className = 'calendar-item';
+      const input = document.createElement('input');
+      input.type = 'radio';
+      input.name = cal.id; // unique group per calendar
+      input.addEventListener('click', function () {
+        if (this.checked && this.dataset.waschecked === 'true') {
+          this.checked = false;
+          this.dataset.waschecked = 'false';
+          selectedCalendars.delete(cal.id);
+        } else {
+          this.dataset.waschecked = 'true';
+          selectedCalendars.add(cal.id);
+        }
+        updateEvents();
+        saveButton.disabled = false;
+      });
+      const span = document.createElement('span');
+      span.textContent = cal.name;
+      label.appendChild(input);
+      label.appendChild(span);
+      calendarsList.appendChild(label);
+      if (userCalendarIds.includes(cal.id)) {
+        input.checked = true;
+        input.dataset.waschecked = 'true';
+        selectedCalendars.add(cal.id);
+      }
+    });
+  }
+
+  function updateEvents() {
+    eventsList.innerHTML = '<div class="skeleton line"></div><div class="skeleton line"></div>';
+    fetchEvents(Array.from(selectedCalendars)).then(events => {
+      eventsList.innerHTML = '';
+      events.forEach(ev => {
+        const div = document.createElement('div');
+        div.textContent = ev.name;
+        eventsList.appendChild(div);
+      });
+    });
+  }
+
+  usernameInput.addEventListener('input', () => {
+    saveButton.disabled = false;
+  });
+
+  saveButton.addEventListener('click', () => {
+    const payload = {
+      username: usernameInput.value,
+      calendars: Array.from(selectedCalendars)
+    };
+    console.log('Saved settings', payload);
+    saveButton.disabled = true;
+  });
+
+  Promise.all([fetchUser(), fetchCalendars()]).then(([user, calendars]) => {
+    usernameInput.value = user.username;
+    usernameSkeleton.classList.add('hidden');
+    usernameInput.classList.remove('hidden');
+
+    renderCalendars(calendars, user.calendars);
+    updateEvents();
+  });
+});

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,53 @@
+:root {
+  --primary-color: #4B5EFF;
+  --accent-color: #FF6F61;
+  --background-color: #F3F6FF;
+}
+
+body {
+  font-family: 'Poppins', sans-serif;
+  background: var(--background-color);
+  margin: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 100vh;
+}
+
+.login-container {
+  text-align: center;
+  padding: 2rem;
+  background: #fff;
+  border-radius: 8px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+}
+
+.logo {
+  width: 80px;
+  height: 80px;
+}
+
+.app-title {
+  color: var(--primary-color);
+  margin: 1rem 0;
+  font-size: 2rem;
+}
+
+.g_id_signin {
+  margin-top: 1rem;
+}
+
+.mock-signin {
+  margin-top: 1rem;
+  padding: 0.5rem 1rem;
+  background: var(--primary-color);
+  color: #fff;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 1rem;
+}
+
+.hidden {
+  display: none;
+}


### PR DESCRIPTION
## Summary
- Add mock Google sign-in button for offline viewing and redirect to settings page
- Move hidden class to global stylesheet and style mock button
- Update README to note mocked data and no server requirement

## Testing
- `npm test` (fails: Could not read package.json)


------
https://chatgpt.com/codex/tasks/task_e_68ae5affab8c832bab0fc1c62830b524