### PR TITLE
Add Harangle login and settings pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,57 @@
+# OS
+.DS_Store
+Thumbs.db
+
+# Node / Web
+node_modules/
+dist/
+build/
+coverage/
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+.env
+
+# Python
+__pycache__/
+*.py[cod]
+*.pyo
+*.pyd
+*.so
+.venv/
+venv/
+ENV/
+env/
+*.egg-info/
+.eggs/
+pip-wheel-metadata/
+.installed.cfg
+*.manifest
+*.spec
+*.cover
+.pytest_cache/
+.coverage
+.mypy_cache/
+.pyre/
+.pytype/
+
+# Java
+*.class
+*.jar
+*.war
+*.ear
+*.iml
+*.iws
+*.ipr
+.idea/
+.mvn/
+.gradle/
+target/
+bin/
+out/
+.classpath
+.project
+.settings/
+hs_err_pid*
+repl_dump.xml

--- a/README.md
+++ b/README.md
@@ -1,1 +1,6 @@
-# harangle-web
+# Harangle Web
+
+This repository contains the login and settings page prototypes for Harangle. Both pages rely on mocked data so they can be opened directly in a browser without running a server.
+
+- Open `index.html` in a browser to view the login page. If the Google sign-in script is unavailable, a mock button allows you to proceed to the settings page.
+- Open `settings.html` to view the settings page where you can edit your username, choose calendars, and review events.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,12 @@
 # Harangle Web
 
-This repository contains prototypes for Harangle's login, group list, settings, and calendar pages. All pages rely on mocked data so they can be opened directly in a browser without running a server.
+This repository contains prototypes for Harangle's login, group list, settings, and calendar pages. A lightweight mock backend (`mock_server.py`) now supplies data to each page.
 
-- Open `index.html` in a browser to view the login page. If the Google sign-in script is unavailable, a mock button allows you to proceed to the groups page.
-- Open `groups.html` to browse existing groups or create a new one. Selecting a group opens `calendar.html` with that group's ID.
-- Open `settings.html` to edit your username, choose calendars, and review events.
-- Open `calendar.html` directly to view the current month's mock schedule powered by FullCalendar and click days to inspect how many hours a user is busy.
+## Running
+
+1. Start the mock server: `python mock_server.py` (listens on `http://localhost:8000`).
+2. Open the pages directly in a browser:
+   - `index.html` shows the login with a fallback mock sign-in button.
+   - `groups.html` lists groups fetched from the backend and links to `calendar.html` with the selected group.
+   - `settings.html` lets you edit your username, choose calendars, and review events from the server.
+   - `calendar.html` displays the current month via FullCalendar and loads busy-hour data for the chosen group.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Harangle Web
 
-This repository contains the login and settings page prototypes for Harangle. Both pages rely on mocked data so they can be opened directly in a browser without running a server.
+This repository contains prototypes for Harangle's login, group list, settings, and calendar pages. All pages rely on mocked data so they can be opened directly in a browser without running a server.
 
-- Open `index.html` in a browser to view the login page. If the Google sign-in script is unavailable, a mock button allows you to proceed to the settings page.
-- Open `settings.html` to view the settings page where you can edit your username, choose calendars, and review events.
+- Open `index.html` in a browser to view the login page. If the Google sign-in script is unavailable, a mock button allows you to proceed to the groups page.
+- Open `groups.html` to browse existing groups or create a new one. Selecting a group opens `calendar.html` with that group's ID.
+- Open `settings.html` to edit your username, choose calendars, and review events.

--- a/README.md
+++ b/README.md
@@ -9,4 +9,4 @@ This repository contains prototypes for Harangle's login, group list, settings, 
    - `http://localhost:8000/index.html` shows the login with a fallback mock sign-in button.
    - `http://localhost:8000/groups.html` lists groups fetched from the backend and links to `calendar.html` with the selected group.
    - `http://localhost:8000/settings.html` lets you edit your username, choose calendars, and review events from the server.
-   - `http://localhost:8000/calendar.html` displays the current month via FullCalendar and loads busy-hour data for the chosen group.
+   - `http://localhost:8000/calendar.html` displays the current month via FullCalendar and loads busy-hour data from the `/days/busy` endpoint.

--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ This repository contains prototypes for Harangle's login, group list, settings, 
 ## Running
 
 1. Start the mock server: `python mock_server.py` (listens on `http://localhost:8000`).
-2. Open the pages directly in a browser:
-   - `index.html` shows the login with a fallback mock sign-in button.
-   - `groups.html` lists groups fetched from the backend and links to `calendar.html` with the selected group.
-   - `settings.html` lets you edit your username, choose calendars, and review events from the server.
-   - `calendar.html` displays the current month via FullCalendar and loads busy-hour data for the chosen group.
+2. Visit the pages through the server in your browser, for example:
+   - `http://localhost:8000/index.html` shows the login with a fallback mock sign-in button.
+   - `http://localhost:8000/groups.html` lists groups fetched from the backend and links to `calendar.html` with the selected group.
+   - `http://localhost:8000/settings.html` lets you edit your username, choose calendars, and review events from the server.
+   - `http://localhost:8000/calendar.html` displays the current month via FullCalendar and loads busy-hour data for the chosen group.

--- a/README.md
+++ b/README.md
@@ -5,3 +5,4 @@ This repository contains prototypes for Harangle's login, group list, settings, 
 - Open `index.html` in a browser to view the login page. If the Google sign-in script is unavailable, a mock button allows you to proceed to the groups page.
 - Open `groups.html` to browse existing groups or create a new one. Selecting a group opens `calendar.html` with that group's ID.
 - Open `settings.html` to edit your username, choose calendars, and review events.
+- Open `calendar.html` directly to view the current month's mock schedule and click days to inspect how many hours a user is busy.

--- a/README.md
+++ b/README.md
@@ -5,4 +5,4 @@ This repository contains prototypes for Harangle's login, group list, settings, 
 - Open `index.html` in a browser to view the login page. If the Google sign-in script is unavailable, a mock button allows you to proceed to the groups page.
 - Open `groups.html` to browse existing groups or create a new one. Selecting a group opens `calendar.html` with that group's ID.
 - Open `settings.html` to edit your username, choose calendars, and review events.
-- Open `calendar.html` directly to view the current month's mock schedule and click days to inspect how many hours a user is busy.
+- Open `calendar.html` directly to view the current month's mock schedule powered by FullCalendar and click days to inspect how many hours a user is busy.

--- a/assets/harangle-icon.svg
+++ b/assets/harangle-icon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <circle cx="50" cy="50" r="50" fill="#4B5EFF"/>
+  <text x="50" y="58" font-family="Poppins, sans-serif" font-size="60" fill="#FFFFFF" text-anchor="middle">H</text>
+</svg>

--- a/calendar.css
+++ b/calendar.css
@@ -7,21 +7,89 @@ body {
 }
 
 .calendar-container {
-  max-width: 600px;
+  max-width: 900px;
   margin: 0 auto;
   background: #fff;
   padding: 1rem 2rem 2rem;
   border-radius: 10px;
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
-  text-align: center;
 }
 
 .page-title {
   color: var(--primary-color);
   margin-top: 0;
+  text-align: center;
 }
 
 .group-info {
-  font-size: 1.2rem;
-  margin-top: 1rem;
+  text-align: center;
 }
+
+.month-year {
+  text-align: center;
+  margin: 0.5rem 0 1rem;
+}
+
+.calendar-wrapper {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+@media (min-width: 700px) {
+  .calendar-wrapper {
+    flex-direction: row;
+  }
+}
+
+.calendar-grid {
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+  gap: 0.25rem;
+  text-align: center;
+  flex: 2;
+}
+
+.day-name {
+  font-weight: bold;
+}
+
+.day {
+  padding: 0.75rem;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.day:hover {
+  opacity: 0.8;
+}
+
+.day.bright {
+  background: #00e676;
+}
+
+.day.medium {
+  background: #66bb6a;
+}
+
+.day.dull {
+  background: #a5d6a7;
+}
+
+.day.tan {
+  background: #d2b48c;
+}
+
+.day-detail {
+  flex: 1;
+  background: #fff;
+  border-radius: 10px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+  padding: 1rem;
+  display: none;
+}
+
+.day-detail.active {
+  display: block;
+}
+

--- a/calendar.css
+++ b/calendar.css
@@ -72,24 +72,35 @@ body {
   background: var(--accent-color);
 }
 
-.fc-daygrid-day.bright {
-  background: #4caf50;
-  color: #fff;
+
+/* busy level indicator */
+.fc-daygrid-day {
+  position: relative;
 }
 
-.fc-daygrid-day.medium {
-  background: #81c784;
-  color: #fff;
+.busy-dot {
+  position: absolute;
+  top: 4px;
+  right: 4px;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
 }
 
-.fc-daygrid-day.dull {
-  background: #c8e6c9;
-  color: #2e7d32;
+.busy-high {
+  background: #d32f2f;
 }
 
-.fc-daygrid-day.tan {
-  background: #e6d5b8;
-  color: #5d4037;
+.busy-medium {
+  background: #fbc02d;
+}
+
+.busy-low {
+  background: #388e3c;
+}
+
+.free {
+  background: #9e9e9e;
 }
 
 .fc-daygrid-day.selected {

--- a/calendar.css
+++ b/calendar.css
@@ -7,7 +7,7 @@ body {
 }
 
 .calendar-container {
-  max-width: 900px;
+  max-width: 1100px;
   margin: 0 auto;
   background: #fff;
   padding: 1rem 2rem 2rem;
@@ -45,6 +45,11 @@ body {
 #calendar {
   flex: 2;
   --fc-border-color: #e0e0e0;
+  overflow: hidden;
+}
+
+#calendar .fc-scroller {
+  overflow: hidden !important;
 }
 
 .fc .fc-toolbar.fc-header-toolbar {
@@ -95,6 +100,7 @@ body {
   padding: 1rem;
   display: none;
   min-width: 200px;
+  position: relative;
 }
 
 .day-detail.active {
@@ -104,5 +110,16 @@ body {
 .day-detail h3 {
   margin-top: 0;
   color: var(--primary-color);
+}
+
+.close-detail {
+  position: absolute;
+  top: 0.25rem;
+  right: 0.25rem;
+  background: none;
+  border: none;
+  font-size: 1.2rem;
+  color: var(--primary-color);
+  cursor: pointer;
 }
 

--- a/calendar.css
+++ b/calendar.css
@@ -92,6 +92,10 @@ body {
   color: #5d4037;
 }
 
+.fc-daygrid-day.selected {
+  box-shadow: inset 0 0 0 3px var(--accent-color);
+}
+
 .day-detail {
   flex: 1;
   background: #fff;

--- a/calendar.css
+++ b/calendar.css
@@ -21,15 +21,6 @@ body {
   text-align: center;
 }
 
-.group-info {
-  text-align: center;
-}
-
-.month-year {
-  text-align: center;
-  margin: 0.5rem 0 1rem;
-}
-
 .calendar-wrapper {
   display: flex;
   flex-direction: column;
@@ -115,6 +106,15 @@ body {
 .day-detail h3 {
   margin-top: 0;
   color: var(--primary-color);
+}
+
+.day-detail ul {
+  list-style: none;
+  padding-left: 1rem;
+}
+
+.day-detail li {
+  margin: 0.25rem 0;
 }
 
 .close-detail {

--- a/calendar.css
+++ b/calendar.css
@@ -80,27 +80,17 @@ body {
 
 .busy-dot {
   position: absolute;
-  top: 4px;
-  right: 4px;
+  bottom: 4px;
+  left: 50%;
+  transform: translateX(-50%);
   width: 8px;
   height: 8px;
   border-radius: 50%;
+  z-index: 2;
 }
 
-.busy-high {
-  background: #d32f2f;
-}
-
-.busy-medium {
-  background: #fbc02d;
-}
-
-.busy-low {
+.busy-good {
   background: #388e3c;
-}
-
-.free {
-  background: #9e9e9e;
 }
 
 .fc-daygrid-day.selected {

--- a/calendar.css
+++ b/calendar.css
@@ -45,51 +45,82 @@ body {
 .calendar-grid {
   display: grid;
   grid-template-columns: repeat(7, 1fr);
-  gap: 0.25rem;
+  border: 1px solid #e0e0e0;
+  border-radius: 8px;
+  overflow: hidden;
   text-align: center;
   flex: 2;
 }
 
+.day-name,
+.day {
+  padding: 0.75rem;
+  border-right: 1px solid #e0e0e0;
+  border-bottom: 1px solid #e0e0e0;
+}
+
+.calendar-grid > :nth-child(7n) {
+  border-right: none;
+}
+
 .day-name {
-  font-weight: bold;
+  background: var(--primary-color);
+  color: #fff;
+  font-weight: 600;
 }
 
 .day {
-  padding: 0.75rem;
-  border-radius: 4px;
+  background: #fff;
+  min-height: 90px;
+  display: flex;
+  align-items: flex-start;
+  justify-content: flex-end;
+  font-weight: 600;
+  transition: background 0.2s ease, transform 0.2s ease;
   cursor: pointer;
 }
 
 .day:hover {
-  opacity: 0.8;
+  background: #f0f4ff;
+  transform: translateY(-2px);
 }
 
 .day.bright {
-  background: #00e676;
+  background: #4caf50;
+  color: #fff;
 }
 
 .day.medium {
-  background: #66bb6a;
+  background: #81c784;
+  color: #fff;
 }
 
 .day.dull {
-  background: #a5d6a7;
+  background: #c8e6c9;
+  color: #2e7d32;
 }
 
 .day.tan {
-  background: #d2b48c;
+  background: #e6d5b8;
+  color: #5d4037;
 }
 
 .day-detail {
   flex: 1;
   background: #fff;
-  border-radius: 10px;
+  border-radius: 8px;
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
   padding: 1rem;
   display: none;
+  min-width: 200px;
 }
 
 .day-detail.active {
   display: block;
+}
+
+.day-detail h3 {
+  margin-top: 0;
+  color: var(--primary-color);
 }
 

--- a/calendar.css
+++ b/calendar.css
@@ -71,6 +71,8 @@ body {
 
 .fc-daygrid-day.good-day {
   background: #c8e6c9;
+  box-shadow: inset 0 0 0 3px #fff;
+  border-radius: 4px;
 }
 
 .fc-daygrid-day.selected {

--- a/calendar.css
+++ b/calendar.css
@@ -42,65 +42,27 @@ body {
   }
 }
 
-.calendar-grid {
-  display: grid;
-  grid-template-columns: repeat(7, 1fr);
-  border: 1px solid #e0e0e0;
-  border-radius: 8px;
-  overflow: hidden;
-  text-align: center;
+#calendar {
   flex: 2;
+  --fc-border-color: #e0e0e0;
 }
 
-.day-name,
-.day {
-  padding: 0.75rem;
-  border-right: 1px solid #e0e0e0;
-  border-bottom: 1px solid #e0e0e0;
-}
-
-.calendar-grid > :nth-child(7n) {
-  border-right: none;
-}
-
-.day-name {
-  background: var(--primary-color);
-  color: #fff;
-  font-weight: 600;
-}
-
-.day {
-  background: #fff;
-  min-height: 90px;
-  display: flex;
-  align-items: flex-start;
-  justify-content: flex-end;
-  font-weight: 600;
-  transition: background 0.2s ease, transform 0.2s ease;
-  cursor: pointer;
-}
-
-.day:hover {
-  background: #f0f4ff;
-  transform: translateY(-2px);
-}
-
-.day.bright {
+.fc-daygrid-day.bright {
   background: #4caf50;
   color: #fff;
 }
 
-.day.medium {
+.fc-daygrid-day.medium {
   background: #81c784;
   color: #fff;
 }
 
-.day.dull {
+.fc-daygrid-day.dull {
   background: #c8e6c9;
   color: #2e7d32;
 }
 
-.day.tan {
+.fc-daygrid-day.tan {
   background: #e6d5b8;
   color: #5d4037;
 }

--- a/calendar.css
+++ b/calendar.css
@@ -47,6 +47,26 @@ body {
   --fc-border-color: #e0e0e0;
 }
 
+.fc .fc-toolbar.fc-header-toolbar {
+  padding: 0.5rem 0;
+  margin-bottom: 1rem;
+}
+
+.fc .fc-toolbar-title {
+  color: var(--primary-color);
+  font-weight: 600;
+}
+
+.fc .fc-button-primary {
+  background: var(--primary-color);
+  border: none;
+  text-transform: capitalize;
+}
+
+.fc .fc-button-primary:not(:disabled):hover {
+  background: var(--accent-color);
+}
+
 .fc-daygrid-day.bright {
   background: #4caf50;
   color: #fff;

--- a/calendar.css
+++ b/calendar.css
@@ -64,24 +64,13 @@ body {
 }
 
 
-/* busy level indicator */
+/* highlight for good availability */
 .fc-daygrid-day {
   position: relative;
 }
 
-.busy-dot {
-  position: absolute;
-  bottom: 4px;
-  left: 50%;
-  transform: translateX(-50%);
-  width: 8px;
-  height: 8px;
-  border-radius: 50%;
-  z-index: 2;
-}
-
-.busy-good {
-  background: #388e3c;
+.fc-daygrid-day.good-day {
+  background: #c8e6c9;
 }
 
 .fc-daygrid-day.selected {

--- a/calendar.css
+++ b/calendar.css
@@ -1,0 +1,27 @@
+body {
+  font-family: 'Poppins', sans-serif;
+  background: var(--background-color);
+  margin: 0;
+  padding: 2rem;
+  display: block;
+}
+
+.calendar-container {
+  max-width: 600px;
+  margin: 0 auto;
+  background: #fff;
+  padding: 1rem 2rem 2rem;
+  border-radius: 10px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+  text-align: center;
+}
+
+.page-title {
+  color: var(--primary-color);
+  margin-top: 0;
+}
+
+.group-info {
+  font-size: 1.2rem;
+  margin-top: 1rem;
+}

--- a/calendar.html
+++ b/calendar.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Harangle - Calendar</title>
+  <link rel="icon" type="image/svg+xml" href="assets/harangle-icon.svg" />
+  <link rel="stylesheet" href="styles.css" />
+  <link rel="stylesheet" href="calendar.css" />
+  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&display=swap" rel="stylesheet" />
+  <script defer src="calendar.js"></script>
+</head>
+<body>
+  <main class="calendar-container">
+    <h1 class="page-title">Calendar</h1>
+    <p id="group-info" class="group-info"></p>
+  </main>
+</body>
+</html>

--- a/calendar.html
+++ b/calendar.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
-  <title>Harangle - Calendar</title>
+  <title>Harangle</title>
   <link rel="icon" type="image/svg+xml" href="assets/harangle-icon.svg" />
   <link rel="stylesheet" href="styles.css" />
   <link rel="stylesheet" href="calendar.css" />
@@ -13,9 +13,7 @@
 </head>
   <body>
     <main class="calendar-container">
-      <h1 class="page-title">Calendar</h1>
-      <p id="group-info" class="group-info"></p>
-      <h2 id="month-year" class="month-year"></h2>
+      <h1 id="group-name" class="page-title"></h1>
       <div class="calendar-wrapper">
         <div id="calendar"></div>
         <div id="day-detail" class="day-detail"></div>

--- a/calendar.html
+++ b/calendar.html
@@ -7,6 +7,8 @@
   <link rel="stylesheet" href="styles.css" />
   <link rel="stylesheet" href="calendar.css" />
   <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&display=swap" rel="stylesheet" />
+  <link href="https://cdn.jsdelivr.net/npm/fullcalendar@6.1.8/index.global.min.css" rel="stylesheet" />
+  <script src="https://cdn.jsdelivr.net/npm/fullcalendar@6.1.8/index.global.min.js"></script>
   <script defer src="calendar.js"></script>
 </head>
   <body>
@@ -15,7 +17,7 @@
       <p id="group-info" class="group-info"></p>
       <h2 id="month-year" class="month-year"></h2>
       <div class="calendar-wrapper">
-        <div id="calendar-grid" class="calendar-grid"></div>
+        <div id="calendar"></div>
         <div id="day-detail" class="day-detail"></div>
       </div>
     </main>

--- a/calendar.html
+++ b/calendar.html
@@ -9,10 +9,15 @@
   <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&display=swap" rel="stylesheet" />
   <script defer src="calendar.js"></script>
 </head>
-<body>
-  <main class="calendar-container">
-    <h1 class="page-title">Calendar</h1>
-    <p id="group-info" class="group-info"></p>
-  </main>
-</body>
-</html>
+  <body>
+    <main class="calendar-container">
+      <h1 class="page-title">Calendar</h1>
+      <p id="group-info" class="group-info"></p>
+      <h2 id="month-year" class="month-year"></h2>
+      <div class="calendar-wrapper">
+        <div id="calendar-grid" class="calendar-grid"></div>
+        <div id="day-detail" class="day-detail"></div>
+      </div>
+    </main>
+  </body>
+  </html>

--- a/calendar.js
+++ b/calendar.js
@@ -1,4 +1,5 @@
 let calendar;
+let selectedCell;
 
 document.addEventListener('DOMContentLoaded', () => {
   const params = new URLSearchParams(window.location.search);
@@ -73,6 +74,7 @@ function colorClass(hours) {
 }
 
 function showDetails(dateStr, hours, user) {
+  selectDay(dateStr);
   const detail = document.getElementById('day-detail');
   detail.innerHTML = `
     <button class="close-detail" aria-label="Close">&times;</button>
@@ -89,6 +91,17 @@ function showDetails(dateStr, hours, user) {
   });
   if (calendar) {
     calendar.updateSize();
+  }
+}
+
+function selectDay(dateStr) {
+  if (selectedCell) {
+    selectedCell.classList.remove('selected');
+  }
+  const cell = document.querySelector(`[data-date="${dateStr}"]`);
+  if (cell) {
+    cell.classList.add('selected');
+    selectedCell = cell;
   }
 }
 

--- a/calendar.js
+++ b/calendar.js
@@ -4,18 +4,13 @@ let selectedCell;
 document.addEventListener('DOMContentLoaded', async () => {
   const params = new URLSearchParams(window.location.search);
   const groupId = params.get('groupId');
-  const info = document.getElementById('group-info');
-  info.textContent = groupId ? `Group ID: ${groupId}` : 'No group selected.';
+  const groupName = params.get('groupName') || 'Calendar';
+  document.getElementById('group-name').textContent = groupName;
+  document.title = `Harangle - ${groupName}`;
 
-  const user = { id: 'u1', name: 'Mock User' };
   const today = new Date();
   const year = today.getFullYear();
   const month = today.getMonth();
-
-  document.getElementById('month-year').textContent = today.toLocaleString('default', {
-    month: 'long',
-    year: 'numeric',
-  });
 
   const busy = await fetchBusyData(groupId, year, month);
   const calendarEl = document.getElementById('calendar');
@@ -33,20 +28,21 @@ document.addEventListener('DOMContentLoaded', async () => {
         click() {
           calendar.today();
           const dateStr = new Date().toISOString().slice(0, 10);
-          const hours = busy[dateStr] || 0;
-          showDetails(dateStr, hours, user);
+          const dayBusy = busy[dateStr] || {};
+          showDetails(dateStr, dayBusy);
         },
       },
     },
     dateClick(infoClick) {
       const dateStr = infoClick.dateStr;
-      const hours = busy[dateStr] || 0;
-      showDetails(dateStr, hours, user);
+      const dayBusy = busy[dateStr] || {};
+      showDetails(dateStr, dayBusy);
     },
     dayCellDidMount(arg) {
       const dateStr = arg.date.toISOString().slice(0, 10);
-      const hours = busy[dateStr] || 0;
-      const cls = colorClass(hours);
+      const dayBusy = busy[dateStr];
+      const total = dayBusy ? Object.values(dayBusy).reduce((a, b) => a + b, 0) : 0;
+      const cls = colorClass(total);
       if (cls) {
         const dot = document.createElement('span');
         dot.className = `busy-dot ${cls}`;
@@ -56,7 +52,7 @@ document.addEventListener('DOMContentLoaded', async () => {
   });
   calendar.render();
   const todayStr = today.toISOString().slice(0, 10);
-  showDetails(todayStr, busy[todayStr] || 0, user);
+  showDetails(todayStr, busy[todayStr] || {});
 });
 
 function fetchBusyData(groupId, year, month) {
@@ -70,13 +66,15 @@ function colorClass(hours) {
   return hours <= 4 ? 'busy-good' : '';
 }
 
-function showDetails(dateStr, hours, user) {
+function showDetails(dateStr, dayBusy) {
   selectDay(dateStr);
   const detail = document.getElementById('day-detail');
+  const formatted = formatDisplayDate(dateStr);
+  const items = Object.entries(dayBusy).map(([name, hrs]) => `<li>${name} is busy for ${hrs} hours.</li>`).join('');
   detail.innerHTML = `
     <button class="close-detail" aria-label="Close">&times;</button>
-    <h3>${dateStr}</h3>
-    <p>${user.name} (ID: ${user.id}) is busy for ${hours} hours.</p>
+    <h3>${formatted}</h3>
+    <ul>${items}</ul>
   `;
   detail.classList.add('active');
   detail.querySelector('.close-detail').addEventListener('click', () => {
@@ -88,6 +86,24 @@ function showDetails(dateStr, hours, user) {
   });
   if (calendar) {
     calendar.updateSize();
+  }
+}
+
+function formatDisplayDate(dateStr) {
+  const date = new Date(dateStr);
+  const weekday = date.toLocaleDateString('en-US', { weekday: 'long' });
+  const month = date.toLocaleDateString('en-US', { month: 'long' });
+  const day = date.getDate();
+  return `${weekday}, ${month} ${day}${ordinal(day)}`;
+}
+
+function ordinal(n) {
+  if (n >= 11 && n <= 13) return 'th';
+  switch (n % 10) {
+    case 1: return 'st';
+    case 2: return 'nd';
+    case 3: return 'rd';
+    default: return 'th';
   }
 }
 

--- a/calendar.js
+++ b/calendar.js
@@ -54,9 +54,23 @@ document.addEventListener('DOMContentLoaded', async () => {
 });
 
 function fetchBusyData(groupId, year, month) {
-  const monthStr = `${year}-${String(month + 1).padStart(2, '0')}`;
-  return fetch(`http://localhost:8000/api/groups/${encodeURIComponent(groupId)}/busy?month=${monthStr}`)
+  const base = 'http://localhost:8000/days/busy';
+  const url = groupId ? `${base}?groupId=${encodeURIComponent(groupId)}` : base;
+  return fetch(url)
     .then(res => res.json())
+    .then((rows) => {
+      const byDay = {};
+      rows.forEach(({ name, busy }) => {
+        Object.entries(busy).forEach(([date, hrs]) => {
+          const d = new Date(date);
+          if (d.getFullYear() === year && d.getMonth() === month) {
+            if (!byDay[date]) byDay[date] = {};
+            byDay[date][name] = hrs;
+          }
+        });
+      });
+      return byDay;
+    })
     .catch(() => ({}));
 }
 

--- a/calendar.js
+++ b/calendar.js
@@ -61,8 +61,19 @@ function colorClass(hours) {
 
 function showDetails(dateStr, hours, user) {
   const detail = document.getElementById('day-detail');
-  detail.innerHTML = `<h3>${dateStr}</h3><p>${user.name} (ID: ${user.id}) is busy for ${hours} hours.</p>`;
+  detail.innerHTML = `
+    <button class="close-detail" aria-label="Close">&times;</button>
+    <h3>${dateStr}</h3>
+    <p>${user.name} (ID: ${user.id}) is busy for ${hours} hours.</p>
+  `;
   detail.classList.add('active');
+  detail.querySelector('.close-detail').addEventListener('click', () => {
+    detail.classList.remove('active');
+    detail.innerHTML = '';
+    if (calendar) {
+      calendar.updateSize();
+    }
+  });
   if (calendar) {
     calendar.updateSize();
   }

--- a/calendar.js
+++ b/calendar.js
@@ -1,0 +1,10 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const params = new URLSearchParams(window.location.search);
+  const groupId = params.get('groupId');
+  const info = document.getElementById('group-info');
+  if (groupId) {
+    info.textContent = `Group ID: ${groupId}`;
+  } else {
+    info.textContent = 'No group selected.';
+  }
+});

--- a/calendar.js
+++ b/calendar.js
@@ -45,10 +45,10 @@ document.addEventListener('DOMContentLoaded', () => {
     },
     dayCellDidMount(arg) {
       const dateStr = arg.date.toISOString().slice(0, 10);
-      const hours = busy[dateStr];
-      if (hours !== undefined) {
-        arg.el.classList.add(colorClass(hours));
-      }
+      const hours = busy[dateStr] || 0;
+      const dot = document.createElement('span');
+      dot.className = `busy-dot ${colorClass(hours)}`;
+      arg.el.appendChild(dot);
     },
   });
   calendar.render();
@@ -67,10 +67,10 @@ function generateBusyData(year, month) {
 }
 
 function colorClass(hours) {
-  if (hours >= 9) return 'bright';
-  if (hours >= 5) return 'medium';
-  if (hours >= 1) return 'dull';
-  return 'tan';
+  if (hours >= 9) return 'busy-high';
+  if (hours >= 5) return 'busy-medium';
+  if (hours >= 1) return 'busy-low';
+  return 'free';
 }
 
 function showDetails(dateStr, hours, user) {

--- a/calendar.js
+++ b/calendar.js
@@ -1,7 +1,7 @@
 let calendar;
 let selectedCell;
 
-document.addEventListener('DOMContentLoaded', () => {
+document.addEventListener('DOMContentLoaded', async () => {
   const params = new URLSearchParams(window.location.search);
   const groupId = params.get('groupId');
   const info = document.getElementById('group-info');
@@ -17,7 +17,7 @@ document.addEventListener('DOMContentLoaded', () => {
     year: 'numeric',
   });
 
-  const busy = generateBusyData(year, month);
+  const busy = await fetchBusyData(groupId, year, month);
   const calendarEl = document.getElementById('calendar');
 
   calendar = new FullCalendar.Calendar(calendarEl, {
@@ -59,14 +59,11 @@ document.addEventListener('DOMContentLoaded', () => {
   showDetails(todayStr, busy[todayStr] || 0, user);
 });
 
-function generateBusyData(year, month) {
-  const daysInMonth = new Date(year, month + 1, 0).getDate();
-  const data = {};
-  for (let d = 1; d <= daysInMonth; d++) {
-    const dateStr = `${year}-${String(month + 1).padStart(2, '0')}-${String(d).padStart(2, '0')}`;
-    data[dateStr] = Math.floor(Math.random() * 13);
-  }
-  return data;
+function fetchBusyData(groupId, year, month) {
+  const monthStr = `${year}-${String(month + 1).padStart(2, '0')}`;
+  return fetch(`http://localhost:8000/api/groups/${encodeURIComponent(groupId)}/busy?month=${monthStr}`)
+    .then(res => res.json())
+    .catch(() => ({}));
 }
 
 function colorClass(hours) {

--- a/calendar.js
+++ b/calendar.js
@@ -26,6 +26,17 @@ document.addEventListener('DOMContentLoaded', () => {
       center: 'title',
       right: 'dayGridMonth,timeGridWeek,timeGridDay',
     },
+    customButtons: {
+      today: {
+        text: 'Today',
+        click() {
+          calendar.today();
+          const dateStr = new Date().toISOString().slice(0, 10);
+          const hours = busy[dateStr] || 0;
+          showDetails(dateStr, hours, user);
+        },
+      },
+    },
     dateClick(infoClick) {
       const dateStr = infoClick.dateStr;
       const hours = busy[dateStr] || 0;
@@ -40,6 +51,8 @@ document.addEventListener('DOMContentLoaded', () => {
     },
   });
   calendar.render();
+  const todayStr = today.toISOString().slice(0, 10);
+  showDetails(todayStr, busy[todayStr] || 0, user);
 });
 
 function generateBusyData(year, month) {

--- a/calendar.js
+++ b/calendar.js
@@ -44,9 +44,7 @@ document.addEventListener('DOMContentLoaded', async () => {
       const total = dayBusy ? Object.values(dayBusy).reduce((a, b) => a + b, 0) : 0;
       const cls = colorClass(total);
       if (cls) {
-        const dot = document.createElement('span');
-        dot.className = `busy-dot ${cls}`;
-        arg.el.appendChild(dot);
+        arg.el.classList.add(cls);
       }
     },
   });
@@ -63,7 +61,7 @@ function fetchBusyData(groupId, year, month) {
 }
 
 function colorClass(hours) {
-  return hours <= 4 ? 'busy-good' : '';
+  return hours <= 4 ? 'good-day' : '';
 }
 
 function showDetails(dateStr, dayBusy) {

--- a/calendar.js
+++ b/calendar.js
@@ -7,4 +7,65 @@ document.addEventListener('DOMContentLoaded', () => {
   } else {
     info.textContent = 'No group selected.';
   }
+
+  const user = { id: 'u1', name: 'Mock User' };
+  const today = new Date();
+  const year = today.getFullYear();
+  const month = today.getMonth();
+
+  document.getElementById('month-year').textContent = today.toLocaleString('default', {
+    month: 'long',
+    year: 'numeric',
+  });
+
+  const busy = generateBusyData(year, month);
+  const grid = document.getElementById('calendar-grid');
+
+  const dayNames = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
+  dayNames.forEach((name) => {
+    const dn = document.createElement('div');
+    dn.textContent = name;
+    dn.className = 'day-name';
+    grid.appendChild(dn);
+  });
+
+  const firstDay = new Date(year, month, 1).getDay();
+  for (let i = 0; i < firstDay; i++) {
+    grid.appendChild(document.createElement('div'));
+  }
+
+  const daysInMonth = new Date(year, month + 1, 0).getDate();
+  for (let day = 1; day <= daysInMonth; day++) {
+    const dateStr = `${year}-${String(month + 1).padStart(2, '0')}-${String(day).padStart(2, '0')}`;
+    const hours = busy[dateStr];
+    const cell = document.createElement('div');
+    cell.textContent = day;
+    cell.className = `day ${colorClass(hours)}`;
+    cell.addEventListener('click', () => showDetails(dateStr, hours, user));
+    grid.appendChild(cell);
+  }
 });
+
+function generateBusyData(year, month) {
+  const daysInMonth = new Date(year, month + 1, 0).getDate();
+  const data = {};
+  for (let d = 1; d <= daysInMonth; d++) {
+    const dateStr = `${year}-${String(month + 1).padStart(2, '0')}-${String(d).padStart(2, '0')}`;
+    data[dateStr] = Math.floor(Math.random() * 13);
+  }
+  return data;
+}
+
+function colorClass(hours) {
+  if (hours >= 9) return 'bright';
+  if (hours >= 5) return 'medium';
+  if (hours >= 1) return 'dull';
+  return 'tan';
+}
+
+function showDetails(dateStr, hours, user) {
+  const detail = document.getElementById('day-detail');
+  detail.innerHTML = `<h3>${dateStr}</h3><p>${user.name} (ID: ${user.id}) is busy for ${hours} hours.</p>`;
+  detail.classList.add('active');
+}
+

--- a/calendar.js
+++ b/calendar.js
@@ -2,11 +2,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const params = new URLSearchParams(window.location.search);
   const groupId = params.get('groupId');
   const info = document.getElementById('group-info');
-  if (groupId) {
-    info.textContent = `Group ID: ${groupId}`;
-  } else {
-    info.textContent = 'No group selected.';
-  }
+  info.textContent = groupId ? `Group ID: ${groupId}` : 'No group selected.';
 
   const user = { id: 'u1', name: 'Mock User' };
   const today = new Date();
@@ -19,31 +15,25 @@ document.addEventListener('DOMContentLoaded', () => {
   });
 
   const busy = generateBusyData(year, month);
-  const grid = document.getElementById('calendar-grid');
+  const calendarEl = document.getElementById('calendar');
 
-  const dayNames = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
-  dayNames.forEach((name) => {
-    const dn = document.createElement('div');
-    dn.textContent = name;
-    dn.className = 'day-name';
-    grid.appendChild(dn);
+  const calendar = new FullCalendar.Calendar(calendarEl, {
+    initialView: 'dayGridMonth',
+    headerToolbar: false,
+    dateClick(infoClick) {
+      const dateStr = infoClick.dateStr;
+      const hours = busy[dateStr] || 0;
+      showDetails(dateStr, hours, user);
+    },
+    dayCellDidMount(arg) {
+      const dateStr = arg.date.toISOString().slice(0, 10);
+      const hours = busy[dateStr];
+      if (hours !== undefined) {
+        arg.el.classList.add(colorClass(hours));
+      }
+    },
   });
-
-  const firstDay = new Date(year, month, 1).getDay();
-  for (let i = 0; i < firstDay; i++) {
-    grid.appendChild(document.createElement('div'));
-  }
-
-  const daysInMonth = new Date(year, month + 1, 0).getDate();
-  for (let day = 1; day <= daysInMonth; day++) {
-    const dateStr = `${year}-${String(month + 1).padStart(2, '0')}-${String(day).padStart(2, '0')}`;
-    const hours = busy[dateStr];
-    const cell = document.createElement('div');
-    cell.textContent = day;
-    cell.className = `day ${colorClass(hours)}`;
-    cell.addEventListener('click', () => showDetails(dateStr, hours, user));
-    grid.appendChild(cell);
-  }
+  calendar.render();
 });
 
 function generateBusyData(year, month) {

--- a/calendar.js
+++ b/calendar.js
@@ -21,7 +21,11 @@ document.addEventListener('DOMContentLoaded', () => {
 
   calendar = new FullCalendar.Calendar(calendarEl, {
     initialView: 'dayGridMonth',
-    headerToolbar: false,
+    headerToolbar: {
+      left: 'prev,next today',
+      center: 'title',
+      right: 'dayGridMonth,timeGridWeek,timeGridDay',
+    },
     dateClick(infoClick) {
       const dateStr = infoClick.dateStr;
       const hours = busy[dateStr] || 0;

--- a/calendar.js
+++ b/calendar.js
@@ -46,9 +46,12 @@ document.addEventListener('DOMContentLoaded', () => {
     dayCellDidMount(arg) {
       const dateStr = arg.date.toISOString().slice(0, 10);
       const hours = busy[dateStr] || 0;
-      const dot = document.createElement('span');
-      dot.className = `busy-dot ${colorClass(hours)}`;
-      arg.el.appendChild(dot);
+      const cls = colorClass(hours);
+      if (cls) {
+        const dot = document.createElement('span');
+        dot.className = `busy-dot ${cls}`;
+        arg.el.appendChild(dot);
+      }
     },
   });
   calendar.render();
@@ -67,10 +70,7 @@ function generateBusyData(year, month) {
 }
 
 function colorClass(hours) {
-  if (hours >= 9) return 'busy-high';
-  if (hours >= 5) return 'busy-medium';
-  if (hours >= 1) return 'busy-low';
-  return 'free';
+  return hours <= 4 ? 'busy-good' : '';
 }
 
 function showDetails(dateStr, hours, user) {

--- a/calendar.js
+++ b/calendar.js
@@ -1,3 +1,5 @@
+let calendar;
+
 document.addEventListener('DOMContentLoaded', () => {
   const params = new URLSearchParams(window.location.search);
   const groupId = params.get('groupId');
@@ -17,7 +19,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const busy = generateBusyData(year, month);
   const calendarEl = document.getElementById('calendar');
 
-  const calendar = new FullCalendar.Calendar(calendarEl, {
+  calendar = new FullCalendar.Calendar(calendarEl, {
     initialView: 'dayGridMonth',
     headerToolbar: false,
     dateClick(infoClick) {
@@ -57,5 +59,8 @@ function showDetails(dateStr, hours, user) {
   const detail = document.getElementById('day-detail');
   detail.innerHTML = `<h3>${dateStr}</h3><p>${user.name} (ID: ${user.id}) is busy for ${hours} hours.</p>`;
   detail.classList.add('active');
+  if (calendar) {
+    calendar.updateSize();
+  }
 }
 

--- a/groups.css
+++ b/groups.css
@@ -1,0 +1,82 @@
+body {
+  font-family: 'Poppins', sans-serif;
+  background: var(--background-color);
+  margin: 0;
+  padding: 2rem;
+  display: block;
+}
+
+.groups-container {
+  max-width: 600px;
+  margin: 0 auto;
+  background: #fff;
+  padding: 1rem 2rem 2rem;
+  border-radius: 10px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+}
+
+.page-title {
+  color: var(--primary-color);
+  margin-top: 0;
+  text-align: center;
+}
+
+.groups-list {
+  border: 1px solid #ddd;
+  border-radius: 4px;
+  max-height: 300px;
+  overflow-y: auto;
+  padding: 0.5rem;
+  background: #fff;
+}
+
+.group-item {
+  padding: 0.5rem;
+  border-bottom: 1px solid #eee;
+  cursor: pointer;
+}
+
+.group-item:last-child {
+  border-bottom: none;
+}
+
+.group-item:hover {
+  background: var(--background-color);
+}
+
+button {
+  color: #fff;
+  border: none;
+  padding: 0.75rem 1.5rem;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 1rem;
+  transition: background 0.3s;
+}
+
+.btn-save {
+  background: var(--success-color);
+}
+
+.buttons {
+  display: flex;
+  justify-content: flex-end;
+  margin-top: 1rem;
+}
+
+.skeleton {
+  background: #e0e0e0;
+  border-radius: 4px;
+  animation: pulse 1.5s infinite;
+}
+
+.skeleton.line {
+  height: 1rem;
+  margin-bottom: 0.5rem;
+}
+
+@keyframes pulse {
+  0% { opacity: 1; }
+  50% { opacity: 0.4; }
+  100% { opacity: 1; }
+}

--- a/groups.html
+++ b/groups.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Harangle - Groups</title>
+  <link rel="icon" type="image/svg+xml" href="assets/harangle-icon.svg" />
+  <link rel="stylesheet" href="styles.css" />
+  <link rel="stylesheet" href="groups.css" />
+  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&display=swap" rel="stylesheet" />
+  <script defer src="groups.js"></script>
+</head>
+<body>
+  <main class="groups-container">
+    <h1 class="page-title">Groups</h1>
+    <section class="section">
+      <div id="groups-list" class="groups-list">
+        <div class="skeleton line"></div>
+        <div class="skeleton line"></div>
+      </div>
+    </section>
+    <div class="buttons">
+      <button id="create-group-button" class="btn-save">Create Group</button>
+    </div>
+  </main>
+</body>
+</html>

--- a/groups.js
+++ b/groups.js
@@ -5,14 +5,9 @@ document.addEventListener('DOMContentLoaded', () => {
   let groups = [];
 
   function fetchGroups() {
-    return new Promise(resolve => {
-      setTimeout(() => {
-        resolve([
-          { id: 'group-1', name: 'Family' },
-          { id: 'group-2', name: 'Friends' }
-        ]);
-      }, 800);
-    });
+    return fetch('http://localhost:8000/api/groups')
+      .then(res => res.json())
+      .catch(() => []);
   }
 
   function renderGroups() {
@@ -32,8 +27,16 @@ document.addEventListener('DOMContentLoaded', () => {
     const name = prompt('Enter group name:');
     if (name) {
       const id = 'group-' + Date.now();
-      groups.push({ id, name });
-      renderGroups();
+      fetch('http://localhost:8000/api/groups', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ id, name })
+      }).then(() => {
+        fetchGroups().then(data => {
+          groups = data;
+          renderGroups();
+        });
+      });
     }
   });
 

--- a/groups.js
+++ b/groups.js
@@ -17,7 +17,7 @@ document.addEventListener('DOMContentLoaded', () => {
       div.className = 'group-item';
       div.textContent = group.name;
       div.addEventListener('click', () => {
-        window.location.href = `calendar.html?groupId=${encodeURIComponent(group.id)}`;
+        window.location.href = `calendar.html?groupId=${encodeURIComponent(group.id)}&groupName=${encodeURIComponent(group.name)}`;
       });
       groupsList.appendChild(div);
     });

--- a/groups.js
+++ b/groups.js
@@ -1,0 +1,44 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const groupsList = document.getElementById('groups-list');
+  const createButton = document.getElementById('create-group-button');
+
+  let groups = [];
+
+  function fetchGroups() {
+    return new Promise(resolve => {
+      setTimeout(() => {
+        resolve([
+          { id: 'group-1', name: 'Family' },
+          { id: 'group-2', name: 'Friends' }
+        ]);
+      }, 800);
+    });
+  }
+
+  function renderGroups() {
+    groupsList.innerHTML = '';
+    groups.forEach(group => {
+      const div = document.createElement('div');
+      div.className = 'group-item';
+      div.textContent = group.name;
+      div.addEventListener('click', () => {
+        window.location.href = `calendar.html?groupId=${encodeURIComponent(group.id)}`;
+      });
+      groupsList.appendChild(div);
+    });
+  }
+
+  createButton.addEventListener('click', () => {
+    const name = prompt('Enter group name:');
+    if (name) {
+      const id = 'group-' + Date.now();
+      groups.push({ id, name });
+      renderGroups();
+    }
+  });
+
+  fetchGroups().then(data => {
+    groups = data;
+    renderGroups();
+  });
+});

--- a/index.html
+++ b/index.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Harangle - Sign in</title>
+  <link rel="icon" type="image/svg+xml" href="assets/harangle-icon.svg" />
+  <link rel="stylesheet" href="styles.css" />
+  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&display=swap" rel="stylesheet" />
+  <script src="https://accounts.google.com/gsi/client" async defer></script>
+</head>
+<body>
+  <main class="login-container">
+    <img src="assets/harangle-icon.svg" class="logo" alt="Harangle logo" />
+    <h1 class="app-title">Harangle</h1>
+  <div id="g_id_onload"
+        data-client_id="YOUR_GOOGLE_CLIENT_ID"
+        data-context="signin"
+        data-ux_mode="popup"
+        data-callback="handleCredentialResponse">
+  </div>
+  <div class="g_id_signin" data-type="standard" data-size="large"></div>
+  <button id="mock-signin-button" class="mock-signin hidden">Mock Sign In</button>
+</main>
+<script>
+  function handleCredentialResponse(response) {
+    // Placeholder for handling ID token response.
+    console.log('Google ID token:', response.credential);
+  }
+
+  window.addEventListener('load', () => {
+    if (typeof google === 'undefined') {
+      const mockBtn = document.getElementById('mock-signin-button');
+      mockBtn.classList.remove('hidden');
+      mockBtn.addEventListener('click', () => {
+        console.log('Mock sign-in');
+        window.location.href = 'settings.html';
+      });
+    }
+  });
+</script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -25,6 +25,7 @@
   function handleCredentialResponse(response) {
     // Placeholder for handling ID token response.
     console.log('Google ID token:', response.credential);
+    window.location.href = 'groups.html';
   }
 
   window.addEventListener('load', () => {
@@ -33,7 +34,7 @@
       mockBtn.classList.remove('hidden');
       mockBtn.addEventListener('click', () => {
         console.log('Mock sign-in');
-        window.location.href = 'settings.html';
+        window.location.href = 'groups.html';
       });
     }
   });

--- a/mock_server.py
+++ b/mock_server.py
@@ -1,0 +1,113 @@
+import json
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from urllib.parse import urlparse, parse_qs
+from calendar import monthrange
+import random, datetime
+
+USER = {"username": "HarangleUser", "calendars": ["cal-1", "cal-2"]}
+CALENDARS = [
+    {"id": "cal-1", "name": "Work"},
+    {"id": "cal-2", "name": "Personal"},
+    {"id": "cal-3", "name": "Holidays"}
+]
+EVENTS = {
+    "cal-1": [
+        {"id": "e1", "name": "Team Meeting"},
+        {"id": "e2", "name": "Project Review"}
+    ],
+    "cal-2": [
+        {"id": "e3", "name": "Dentist Appointment"},
+        {"id": "e4", "name": "Gym Session"}
+    ],
+    "cal-3": [
+        {"id": "e5", "name": "Independence Day"}
+    ]
+}
+GROUPS = [
+    {"id": "group-1", "name": "Family"},
+    {"id": "group-2", "name": "Friends"}
+]
+
+class Handler(BaseHTTPRequestHandler):
+    def _set_headers(self):
+        self.send_response(200)
+        self.send_header('Content-Type', 'application/json')
+        self.send_header('Access-Control-Allow-Origin', '*')
+        self.end_headers()
+
+    def do_OPTIONS(self):
+        self.send_response(200)
+        self.send_header('Access-Control-Allow-Origin', '*')
+        self.send_header('Access-Control-Allow-Methods', 'GET, POST, OPTIONS')
+        self.send_header('Access-Control-Allow-Headers', 'Content-Type')
+        self.end_headers()
+
+    def do_GET(self):
+        parsed = urlparse(self.path)
+        if parsed.path == '/api/user':
+            self._set_headers()
+            self.wfile.write(json.dumps(USER).encode())
+        elif parsed.path == '/api/calendars':
+            self._set_headers()
+            self.wfile.write(json.dumps(CALENDARS).encode())
+        elif parsed.path == '/api/events':
+            qs = parse_qs(parsed.query)
+            ids = qs.get('ids', [''])[0].split(',') if 'ids' in qs else []
+            events = []
+            for cid in ids:
+                events.extend(EVENTS.get(cid, []))
+            self._set_headers()
+            self.wfile.write(json.dumps(events).encode())
+        elif parsed.path == '/api/groups':
+            self._set_headers()
+            self.wfile.write(json.dumps(GROUPS).encode())
+        elif parsed.path.startswith('/api/groups/') and parsed.path.endswith('/busy'):
+            parts = parsed.path.split('/')
+            if len(parts) >= 5:
+                group_id = parts[3]
+            else:
+                self.send_error(404)
+                return
+            qs = parse_qs(parsed.query)
+            month_str = qs.get('month', [''])[0]
+            if month_str:
+                year, month = map(int, month_str.split('-'))
+            else:
+                today = datetime.date.today()
+                year, month = today.year, today.month
+            days = monthrange(year, month)[1]
+            data = {}
+            for d in range(1, days + 1):
+                date_str = f"{year:04d}-{month:02d}-{d:02d}"
+                data[date_str] = random.randint(0, 12)
+            self._set_headers()
+            self.wfile.write(json.dumps(data).encode())
+        else:
+            self.send_error(404)
+
+    def do_POST(self):
+        parsed = urlparse(self.path)
+        length = int(self.headers.get('Content-Length', 0))
+        body = self.rfile.read(length).decode()
+        if parsed.path == '/api/user':
+            data = json.loads(body or '{}')
+            USER['username'] = data.get('username', USER['username'])
+            USER['calendars'] = data.get('calendars', USER['calendars'])
+            self._set_headers()
+            self.wfile.write(json.dumps({'status': 'ok'}).encode())
+        elif parsed.path == '/api/groups':
+            data = json.loads(body or '{}')
+            GROUPS.append(data)
+            self._set_headers()
+            self.wfile.write(json.dumps(data).encode())
+        else:
+            self.send_error(404)
+
+
+def run(port=8000):
+    server = HTTPServer(('', port), Handler)
+    print(f"Mock server running on port {port}")
+    server.serve_forever()
+
+if __name__ == '__main__':
+    run()

--- a/mock_server.py
+++ b/mock_server.py
@@ -1,5 +1,5 @@
 import json
-from http.server import BaseHTTPRequestHandler, HTTPServer
+from http.server import SimpleHTTPRequestHandler, HTTPServer
 from urllib.parse import urlparse, parse_qs
 from calendar import monthrange
 import random, datetime
@@ -28,7 +28,7 @@ GROUPS = [
     {"id": "group-2", "name": "Friends"}
 ]
 
-class Handler(BaseHTTPRequestHandler):
+class Handler(SimpleHTTPRequestHandler):
     def _set_headers(self):
         self.send_response(200)
         self.send_header('Content-Type', 'application/json')
@@ -83,7 +83,7 @@ class Handler(BaseHTTPRequestHandler):
             self._set_headers()
             self.wfile.write(json.dumps(data).encode())
         else:
-            self.send_error(404)
+            super().do_GET()
 
     def do_POST(self):
         parsed = urlparse(self.path)

--- a/mock_server.py
+++ b/mock_server.py
@@ -20,13 +20,15 @@ EVENTS = {
         {"id": "e4", "name": "Gym Session"}
     ],
     "cal-3": [
-        {"id": "e5", "name": "Independence Day"}
+    {"id": "e5", "name": "Independence Day"}
     ]
 }
 GROUPS = [
     {"id": "group-1", "name": "Family"},
     {"id": "group-2", "name": "Friends"}
 ]
+
+USERS = ["Jack", "Catherine", "Rob", "Elisa", "Marcus", "Sophie"]
 
 class Handler(SimpleHTTPRequestHandler):
     def _set_headers(self):
@@ -79,7 +81,7 @@ class Handler(SimpleHTTPRequestHandler):
             data = {}
             for d in range(1, days + 1):
                 date_str = f"{year:04d}-{month:02d}-{d:02d}"
-                data[date_str] = random.randint(0, 12)
+                data[date_str] = {name: random.randint(0, 12) for name in USERS}
             self._set_headers()
             self.wfile.write(json.dumps(data).encode())
         else:

--- a/mock_server.py
+++ b/mock_server.py
@@ -84,6 +84,18 @@ class Handler(SimpleHTTPRequestHandler):
                 data[date_str] = {name: random.randint(0, 12) for name in USERS}
             self._set_headers()
             self.wfile.write(json.dumps(data).encode())
+        elif parsed.path == '/days/busy':
+            today = datetime.date.today()
+            days = monthrange(today.year, today.month)[1]
+            result = []
+            for name in USERS:
+                busy = {}
+                for d in range(1, days + 1):
+                    date_str = f"{today.year:04d}-{today.month:02d}-{d:02d}"
+                    busy[date_str] = random.randint(0, 12)
+                result.append({"name": name, "busy": busy})
+            self._set_headers()
+            self.wfile.write(json.dumps(result).encode())
         else:
             super().do_GET()
 

--- a/settings.css
+++ b/settings.css
@@ -1,0 +1,130 @@
+body {
+  font-family: 'Poppins', sans-serif;
+  background: var(--background-color);
+  margin: 0;
+  padding: 2rem;
+  display: block;
+}
+
+
+.settings-container {
+  max-width: 600px;
+  margin: 0 auto;
+  background: #fff;
+  padding: 1rem 2rem 2rem;
+  border-radius: 10px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+}
+
+.page-title {
+  color: var(--primary-color);
+  margin-top: 0;
+  text-align: center;
+}
+
+.section {
+  margin-bottom: 2rem;
+}
+
+.calendars-list .calendar-item {
+  display: flex;
+  align-items: center;
+  padding: 0.4rem 0.6rem;
+  border: 1px solid #ddd;
+  border-radius: 4px;
+  margin-bottom: 0.5rem;
+  transition: background 0.3s, border-color 0.3s;
+}
+
+.calendar-item input[type="radio"] {
+  margin-right: 0.5rem;
+  accent-color: var(--primary-color);
+}
+
+.calendar-item.selected {
+  background: var(--background-color);
+  border-color: var(--primary-color);
+}
+
+.events-list {
+  max-height: 200px;
+  overflow-y: auto;
+  border: 1px solid #ddd;
+  padding: 0.5rem;
+  background: #fff;
+  border-radius: 4px;
+}
+
+.events-list div {
+  padding: 0.3rem 0.5rem;
+  border-bottom: 1px solid #eee;
+}
+
+.events-list div:last-child {
+  border-bottom: none;
+}
+
+button {
+  color: #fff;
+  border: none;
+  padding: 0.75rem 1.5rem;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 1rem;
+  transition: background 0.3s;
+}
+
+button:disabled {
+  background: #ccc;
+  cursor: not-allowed;
+}
+
+.btn-save {
+  background: var(--success-color);
+}
+
+.btn-cancel {
+  background: var(--danger-color);
+}
+
+.buttons {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.5rem;
+}
+
+#username-input {
+  width: 100%;
+  padding: 0.75rem;
+  font-size: 1.1rem;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+}
+
+.username-section label {
+  display: block;
+  font-weight: 600;
+  margin-bottom: 0.5rem;
+}
+
+.skeleton {
+  background: #e0e0e0;
+  border-radius: 4px;
+  animation: pulse 1.5s infinite;
+}
+
+.skeleton.line {
+  height: 1rem;
+  margin-bottom: 0.5rem;
+}
+
+.skeleton.input {
+  height: 2rem;
+  width: 100%;
+}
+
+@keyframes pulse {
+  0% { opacity: 1; }
+  50% { opacity: 0.4; }
+  100% { opacity: 1; }
+}

--- a/settings.html
+++ b/settings.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Harangle - Settings</title>
+  <link rel="icon" type="image/svg+xml" href="assets/harangle-icon.svg" />
+  <link rel="stylesheet" href="styles.css" />
+  <link rel="stylesheet" href="settings.css" />
+  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&display=swap" rel="stylesheet" />
+  <script defer src="settings.js"></script>
+</head>
+<body>
+  <main class="settings-container">
+    <h1 class="page-title">Settings</h1>
+
+    <section class="section username-section">
+      <label for="username-input">Username</label>
+      <div id="username-skeleton" class="skeleton input"></div>
+      <input id="username-input" type="text" class="hidden" />
+    </section>
+
+    <section class="section calendars-section">
+      <h2>Calendars</h2>
+      <div id="calendars-list" class="calendars-list">
+        <div class="skeleton line"></div>
+        <div class="skeleton line"></div>
+      </div>
+    </section>
+
+    <section class="section events-section">
+      <h2>Events</h2>
+      <div id="events-list" class="events-list">
+        <div class="skeleton line"></div>
+        <div class="skeleton line"></div>
+        <div class="skeleton line"></div>
+      </div>
+    </section>
+
+    <div class="buttons">
+      <button id="cancel-button" class="btn-cancel">Cancel</button>
+      <button id="save-button" class="btn-save" disabled>Save</button>
+    </div>
+  </main>
+</body>
+</html>

--- a/settings.js
+++ b/settings.js
@@ -1,0 +1,130 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const usernameInput = document.getElementById('username-input');
+  const usernameSkeleton = document.getElementById('username-skeleton');
+  const calendarsList = document.getElementById('calendars-list');
+  const eventsList = document.getElementById('events-list');
+  const saveButton = document.getElementById('save-button');
+  const cancelButton = document.getElementById('cancel-button');
+
+  let selectedCalendars = new Set();
+
+  function fetchUser() {
+    return new Promise(resolve => {
+      setTimeout(() => {
+        resolve({ username: 'HarangleUser', calendars: ['cal-1', 'cal-2'] });
+      }, 800);
+    });
+  }
+
+  function fetchCalendars() {
+    return new Promise(resolve => {
+      setTimeout(() => {
+        resolve([
+          { id: 'cal-1', name: 'Work' },
+          { id: 'cal-2', name: 'Personal' },
+          { id: 'cal-3', name: 'Holidays' }
+        ]);
+      }, 1000);
+    });
+  }
+
+  const eventData = {
+    'cal-1': [
+      { id: 'e1', name: 'Team Meeting' },
+      { id: 'e2', name: 'Project Review' }
+    ],
+    'cal-2': [
+      { id: 'e3', name: 'Dentist Appointment' },
+      { id: 'e4', name: 'Gym Session' }
+    ],
+    'cal-3': [
+      { id: 'e5', name: 'Independence Day' }
+    ]
+  };
+
+  function fetchEvents(ids) {
+    return new Promise(resolve => {
+      setTimeout(() => {
+        let events = [];
+        ids.forEach(id => {
+          events = events.concat(eventData[id] || []);
+        });
+        resolve(events);
+      }, 700);
+    });
+  }
+
+  function renderCalendars(calendars, userCalendarIds) {
+    calendarsList.innerHTML = '';
+    calendars.forEach(cal => {
+      const label = document.createElement('label');
+      label.className = 'calendar-item';
+      const input = document.createElement('input');
+      input.type = 'radio';
+      input.name = cal.id; // unique group per calendar
+      input.addEventListener('click', function () {
+        if (this.checked && this.dataset.waschecked === 'true') {
+          this.checked = false;
+          this.dataset.waschecked = 'false';
+          selectedCalendars.delete(cal.id);
+          label.classList.remove('selected');
+        } else {
+          this.dataset.waschecked = 'true';
+          selectedCalendars.add(cal.id);
+          label.classList.add('selected');
+        }
+        updateEvents();
+        saveButton.disabled = false;
+      });
+      const span = document.createElement('span');
+      span.textContent = cal.name;
+      label.appendChild(input);
+      label.appendChild(span);
+      calendarsList.appendChild(label);
+      if (userCalendarIds.includes(cal.id)) {
+        input.checked = true;
+        input.dataset.waschecked = 'true';
+        selectedCalendars.add(cal.id);
+        label.classList.add('selected');
+      }
+    });
+  }
+
+  function updateEvents() {
+    eventsList.innerHTML = '<div class="skeleton line"></div><div class="skeleton line"></div>';
+    fetchEvents(Array.from(selectedCalendars)).then(events => {
+      eventsList.innerHTML = '';
+      events.forEach(ev => {
+        const div = document.createElement('div');
+        div.textContent = ev.name;
+        eventsList.appendChild(div);
+      });
+    });
+  }
+
+  usernameInput.addEventListener('input', () => {
+    saveButton.disabled = false;
+  });
+
+  saveButton.addEventListener('click', () => {
+    const payload = {
+      username: usernameInput.value,
+      calendars: Array.from(selectedCalendars)
+    };
+    console.log('Saved settings', payload);
+    saveButton.disabled = true;
+  });
+
+  cancelButton.addEventListener('click', () => {
+    location.reload();
+  });
+
+  Promise.all([fetchUser(), fetchCalendars()]).then(([user, calendars]) => {
+    usernameInput.value = user.username;
+    usernameSkeleton.classList.add('hidden');
+    usernameInput.classList.remove('hidden');
+
+    renderCalendars(calendars, user.calendars);
+    updateEvents();
+  });
+});

--- a/settings.js
+++ b/settings.js
@@ -9,49 +9,22 @@ document.addEventListener('DOMContentLoaded', () => {
   let selectedCalendars = new Set();
 
   function fetchUser() {
-    return new Promise(resolve => {
-      setTimeout(() => {
-        resolve({ username: 'HarangleUser', calendars: ['cal-1', 'cal-2'] });
-      }, 800);
-    });
+    return fetch('http://localhost:8000/api/user')
+      .then(res => res.json())
+      .catch(() => ({ username: '', calendars: [] }));
   }
 
   function fetchCalendars() {
-    return new Promise(resolve => {
-      setTimeout(() => {
-        resolve([
-          { id: 'cal-1', name: 'Work' },
-          { id: 'cal-2', name: 'Personal' },
-          { id: 'cal-3', name: 'Holidays' }
-        ]);
-      }, 1000);
-    });
+    return fetch('http://localhost:8000/api/calendars')
+      .then(res => res.json())
+      .catch(() => []);
   }
 
-  const eventData = {
-    'cal-1': [
-      { id: 'e1', name: 'Team Meeting' },
-      { id: 'e2', name: 'Project Review' }
-    ],
-    'cal-2': [
-      { id: 'e3', name: 'Dentist Appointment' },
-      { id: 'e4', name: 'Gym Session' }
-    ],
-    'cal-3': [
-      { id: 'e5', name: 'Independence Day' }
-    ]
-  };
-
   function fetchEvents(ids) {
-    return new Promise(resolve => {
-      setTimeout(() => {
-        let events = [];
-        ids.forEach(id => {
-          events = events.concat(eventData[id] || []);
-        });
-        resolve(events);
-      }, 700);
-    });
+    const query = ids.length ? `?ids=${ids.join(',')}` : '';
+    return fetch(`http://localhost:8000/api/events${query}`)
+      .then(res => res.json())
+      .catch(() => []);
   }
 
   function renderCalendars(calendars, userCalendarIds) {
@@ -111,8 +84,14 @@ document.addEventListener('DOMContentLoaded', () => {
       username: usernameInput.value,
       calendars: Array.from(selectedCalendars)
     };
-    console.log('Saved settings', payload);
-    saveButton.disabled = true;
+    fetch('http://localhost:8000/api/user', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload)
+    }).then(() => {
+      console.log('Saved settings', payload);
+      saveButton.disabled = true;
+    });
   });
 
   cancelButton.addEventListener('click', () => {

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,55 @@
+:root {
+  --primary-color: #4B5EFF;
+  --accent-color: #FF6F61;
+  --background-color: #F3F6FF;
+  --success-color: #4CAF50;
+  --danger-color: #F44336;
+}
+
+body {
+  font-family: 'Poppins', sans-serif;
+  background: var(--background-color);
+  margin: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 100vh;
+}
+
+.login-container {
+  text-align: center;
+  padding: 2rem;
+  background: #fff;
+  border-radius: 8px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+}
+
+.logo {
+  width: 80px;
+  height: 80px;
+}
+
+.app-title {
+  color: var(--primary-color);
+  margin: 1rem 0;
+  font-size: 2rem;
+}
+
+.g_id_signin {
+  margin-top: 1rem;
+}
+
+.mock-signin {
+  margin-top: 1rem;
+  padding: 0.5rem 1rem;
+  background: var(--primary-color);
+  color: #fff;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 1rem;
+}
+
+.hidden {
+  display: none;
+}


### PR DESCRIPTION
## Summary
- Add mock Google sign-in button for offline viewing and redirect to settings page
- Move hidden class to global stylesheet and style mock button
- Update README to note mocked data and no server requirement
- Beautify settings page with colored actions and improved layout

## Testing
- `node --check settings.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ae5affab8c832bab0fc1c62830b524